### PR TITLE
Use setuptools-markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # pyramid_default_cors
-Set up default handling of CORS XHR
+
+Set up default handling of CORS XHR in Pyramid.
+
+## Releases
+
+Install [pandoc] 
+
+[pandoc]: http://johnmacfarlane.net/pandoc/
+
+TBD

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name='pyramid_default_cors',
     version='0.2.1',
     description='Default wiring for CORS XHR',
-    long_description='README.md',
+    long_description_markdown_filename='README.md',
     author='Mark Floyd',
     author_email='mark@goodrx.com',
     url='https://github.com/GoodRx/pyramid_default_cors',

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,18 @@
-import os
-
 from setuptools import find_packages
 from setuptools import setup
-
-here = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(here, 'README.md')).read()
 
 setup(
     name='pyramid_default_cors',
     version='0.2.1',
     description='Default wiring for CORS XHR',
-    long_description=README,
+    long_description='README.md',
     author='Mark Floyd',
     author_email='mark@goodrx.com',
     url='https://github.com/GoodRx/pyramid_default_cors',
     keywords='config web wsgi pyramid',
     packages=find_packages(),
     zip_safe=False,
+    setup_requires=[
+        'setuptools-markdown >= 0.2, < 1.0',
+    ],
 )


### PR DESCRIPTION
It should fix the formatting of the docs in PyPi while avoiding the need to setup
Sphinx to generate an RST file.